### PR TITLE
failure handling in FormsKnotProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@ All notable changes to `knotx-forms` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+
+- [PR-10](https://github.com/Knotx/knotx-forms/pull/10) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) - forms

--- a/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
+++ b/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
@@ -114,7 +114,7 @@ public class FormsKnotProxy extends AbstractKnotProxy {
           .get();
       form.fragment().failure(knotId, e);
       if (!form.fragment().fallback().isPresent()) {
-        throw new FragmentProcessingException("From Fragment processing failed", t);
+        throw new FragmentProcessingException("From Fragment processing failed", e);
       }
     }
   }

--- a/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
+++ b/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
@@ -106,13 +106,13 @@ public class FormsKnotProxy extends AbstractKnotProxy {
       form.fragment()
           .content(simplifier.transform(form.fragment().content(), options.getFormIdentifierName(),
               form.identifier()));
-    } catch (Throwable t) {
-      LOGGER.error("Fragment processing failed. Cause:{}\nForm:\n{}\n", t.getMessage(), form);
+    } catch (Exception e) {
+      LOGGER.error("Fragment processing failed. Cause:{}\nForm:\n{}\n", e.getMessage(), form);
       String knotId = form.fragment().knots().stream()
           .filter(knot -> knot.startsWith(FormConstants.FRAGMENT_KNOT_PREFIX))
           .findFirst()
           .get();
-      form.fragment().failure(knotId, t);
+      form.fragment().failure(knotId, e);
       if (!form.fragment().fallback().isPresent()) {
         throw new FragmentProcessingException("From Fragment processing failed", t);
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implementation of new knotx feature (fragment processing faiilure handling) within forms

## Description
New failure handling feature was implemented in https://github.com/Cognifide/knotx/issues/466
This PR allows data bridge to take advantage of the new approach and handle data bridge failures in a more robust way.
## Motivation and Context
See core feature documentation

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
