### PR TITLE
Feature/knotx failure handling

### DIFF
--- a/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
+++ b/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
@@ -73,7 +73,7 @@ public class FormsKnotProxy extends AbstractKnotProxy {
         .flattenAsObservable(KnotContext::getFragments)
         .filter(f -> f.knots().stream().anyMatch(id -> id.startsWith(
             FormConstants.FRAGMENT_KNOT_PREFIX)))
-        .map(f -> Optional.of(FormEntity.from(f, options)))
+        .map(f -> Optional.of(FormEntity.of(f, options)))
         .onErrorReturn(this::handleFallback)
         .filter(Optional::isPresent)
         .map(Optional::get)

--- a/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
+++ b/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
@@ -91,7 +91,7 @@ public class FormsKnotProxy extends AbstractKnotProxy {
   protected KnotContext processError(KnotContext context, Throwable error) {
     LOGGER.error("Could not process template [{}]", context.getClientRequest().getPath(), error);
     KnotContext result = null;
-    if (error instanceof FormConfigurationException &&  ((FormConfigurationException)error).isFallbackDefined()) {
+    if (isFallbackDefined(error)) {
       result = fallback(context);
     } else {
       result = new KnotContext().setClientResponse(context.getClientResponse());

--- a/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
+++ b/core/src/main/java/io/knotx/forms/core/FormsKnotProxy.java
@@ -26,7 +26,6 @@ import io.knotx.forms.api.FormsAdapterResponse;
 import io.knotx.forms.core.domain.FormConfigurationException;
 import io.knotx.forms.core.domain.FormConstants;
 import io.knotx.forms.core.domain.FormEntity;
-import io.knotx.forms.core.domain.FormProcessingException;
 import io.knotx.forms.core.domain.FormTransformer;
 import io.knotx.forms.core.domain.FormsFactory;
 import io.knotx.http.AllowedHeadersFilter;

--- a/core/src/main/java/io/knotx/forms/core/domain/FormConfigurationException.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormConfigurationException.java
@@ -1,0 +1,21 @@
+package io.knotx.forms.core.domain;
+
+import io.knotx.dataobjects.Fragment;
+
+public class FormConfigurationException extends RuntimeException {
+  private boolean fallbackDetected;
+
+  public FormConfigurationException(String message, Throwable cause, boolean fallbackDetected) {
+    super(message, cause);
+    this.fallbackDetected = fallbackDetected;
+  }
+
+  public FormConfigurationException(String message, boolean fallbackDetected) {
+    super(message);
+    this.fallbackDetected = fallbackDetected;
+  }
+
+  public boolean isFallbackDetected() {
+    return fallbackDetected;
+  }
+}

--- a/core/src/main/java/io/knotx/forms/core/domain/FormConfigurationException.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormConfigurationException.java
@@ -1,21 +1,34 @@
+/*
+ * Copyright (C) 2018 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.forms.core.domain;
 
-import io.knotx.dataobjects.Fragment;
-
 public class FormConfigurationException extends RuntimeException {
-  private boolean fallbackDetected;
+  private final boolean fallbackDefined;
 
   public FormConfigurationException(String message, Throwable cause, boolean fallbackDetected) {
     super(message, cause);
-    this.fallbackDetected = fallbackDetected;
+    this.fallbackDefined = fallbackDetected;
   }
 
   public FormConfigurationException(String message, boolean fallbackDetected) {
     super(message);
-    this.fallbackDetected = fallbackDetected;
+    this.fallbackDefined = fallbackDetected;
   }
 
-  public boolean isFallbackDetected() {
-    return fallbackDetected;
+  public boolean isFallbackDefined() {
+    return fallbackDefined;
   }
 }

--- a/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
@@ -48,7 +48,7 @@ public class FormEntity {
 
   private Map<String, String> signalToUrl;
 
-  public static FormEntity from(Fragment fragment, FormsKnotOptions options) {
+  public static FormEntity of(Fragment fragment, FormsKnotOptions options) {
     Element scriptDocument = FragmentContentExtractor.unwrapFragmentContent(fragment);
     try {
       return new FormEntity()

--- a/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
@@ -24,6 +24,7 @@ import io.knotx.fragments.FragmentContentExtractor;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import java.text.Normalizer.Form;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
@@ -48,10 +49,9 @@ public class FormEntity {
   private Map<String, String> signalToUrl;
 
   public static FormEntity from(Fragment fragment, FormsKnotOptions options) {
-    FormEntity result = null;
     Element scriptDocument = FragmentContentExtractor.unwrapFragmentContent(fragment);
     try {
-      result = new FormEntity()
+      return new FormEntity()
           .fragment(fragment)
           .identifier(getFormIdentifier(fragment))
           .adapterParams(getAdapterParams(scriptDocument))
@@ -63,11 +63,8 @@ public class FormEntity {
           .findFirst()
           .get();
       fragment.failure(knotId, e);
-      if (!fragment.fallback().isPresent()) {
-        throw new FormConfigurationException(e.getMessage(), e.getCause(), fragment.fallback().isPresent());
-      }
+      throw new FormConfigurationException(e.getMessage(), e.getCause(), fragment.fallback().isPresent());
     }
-    return result;
   }
 
   public Fragment fragment() {
@@ -97,7 +94,7 @@ public class FormEntity {
   }
 
   private static Optional<String> getFormIdentifierFromRequest(KnotContext knotContext,
-      String formIdAttrName) {
+                                                               String formIdAttrName) {
     return Optional.ofNullable(
         knotContext.getClientRequest().getFormAttributes().get(formIdAttrName));
   }
@@ -159,7 +156,7 @@ public class FormEntity {
   }
 
   private static FormsKnotDefinition getAdapterMetadata(FormsKnotOptions options,
-      String adapter) {
+                                                        String adapter) {
     return options.getAdapters().stream()
         .filter(metadata -> metadata.getName().equals(adapter))
         .findFirst()

--- a/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
@@ -48,9 +48,10 @@ public class FormEntity {
   private Map<String, String> signalToUrl;
 
   public static FormEntity from(Fragment fragment, FormsKnotOptions options) {
+    FormEntity result = null;
     Element scriptDocument = FragmentContentExtractor.unwrapFragmentContent(fragment);
     try {
-      return new FormEntity()
+      result = new FormEntity()
           .fragment(fragment)
           .identifier(getFormIdentifier(fragment))
           .adapterParams(getAdapterParams(scriptDocument))
@@ -62,8 +63,11 @@ public class FormEntity {
           .findFirst()
           .get();
       fragment.failure(knotId, e);
-      throw new FormConfigurationException(e.getMessage(), e.getCause(), fragment.fallback().isPresent());
+      if (!fragment.fallback().isPresent()) {
+        throw new FormConfigurationException(e.getMessage(), e.getCause(), fragment.fallback().isPresent());
+      }
     }
+    return result;
   }
 
   public Fragment fragment() {

--- a/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormEntity.java
@@ -49,13 +49,21 @@ public class FormEntity {
 
   public static FormEntity from(Fragment fragment, FormsKnotOptions options) {
     Element scriptDocument = FragmentContentExtractor.unwrapFragmentContent(fragment);
-    return new FormEntity()
-        .fragment(fragment)
-        .identifier(getFormIdentifier(fragment))
-        .adapterParams(getAdapterParams(scriptDocument))
-        .adapter(getAdapterMetadata(options, getAdapterName(fragment, scriptDocument)))
-        .signalToUrlMapping(getSignalToUrlMapping(scriptDocument));
-
+    try {
+      return new FormEntity()
+          .fragment(fragment)
+          .identifier(getFormIdentifier(fragment))
+          .adapterParams(getAdapterParams(scriptDocument))
+          .adapter(getAdapterMetadata(options, getAdapterName(fragment, scriptDocument)))
+          .signalToUrlMapping(getSignalToUrlMapping(scriptDocument));
+    } catch (Exception e) {
+      String knotId = fragment.knots().stream()
+          .filter(knot -> knot.startsWith(FormConstants.FRAGMENT_KNOT_PREFIX))
+          .findFirst()
+          .get();
+      fragment.failure(knotId, e);
+      throw new FormConfigurationException(e.getMessage(), e.getCause(), fragment.fallback().isPresent());
+    }
   }
 
   public Fragment fragment() {

--- a/core/src/main/java/io/knotx/forms/core/domain/FormProcessingException.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormProcessingException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.forms.core.domain;
 
 public class FormProcessingException extends RuntimeException {

--- a/core/src/main/java/io/knotx/forms/core/domain/FormProcessingException.java
+++ b/core/src/main/java/io/knotx/forms/core/domain/FormProcessingException.java
@@ -1,0 +1,7 @@
+package io.knotx.forms.core.domain;
+
+public class FormProcessingException extends RuntimeException {
+  public FormProcessingException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
FormsFactory fallback handling
## Description
Fallback handling was implemented only for form processing layer. Now it should also work if given form fragment is not configured.

## Motivation and Context
Align with data-bridge and other modules which apply fallback when misconfigured

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
